### PR TITLE
Add user account fields back onto new user form.

### DIFF
--- a/karaage/people/templates/people/person_form.html
+++ b/karaage/people/templates/people/person_form.html
@@ -43,12 +43,22 @@
             {% formfield form.fax %}
             {% formfield form.address %}
             {% formfield form.country %}
-            {% formfield form.institute %}
             {% formfield form.comment %}
             {% formfield form.expires %}
             {% formfield form.is_admin %}
             {% formfield form.is_systemuser %}
         </fieldset>
+
+        {% if not person %}
+        <fieldset class="module aligned ()">
+            <h2>User Account Details</h2>
+            {% formfield form.needs_account %}
+            {% formfield form.project %}
+            {% formfield form.username %}
+            {% formfield form.password1 %}
+            {% formfield form.password2 %}
+        </fieldset>
+        {% endif %}
 
         {{ form.non_field_errors }}
     </div>


### PR DESCRIPTION
Adds back the missing person fields that prevent adding a new user.

I don't  really like the order of some of the fields but i other orders don't make much more sense.  I have also removed and duplicate institute field that causes the form to fail to submit if the both aren't filled in.

Fixes #210
