### PR TITLE
Try to eliminate confusion in entering names

### DIFF
--- a/karaage/people/forms.py
+++ b/karaage/people/forms.py
@@ -63,6 +63,15 @@ class PersonForm(forms.ModelForm):
     country = forms.ChoiceField(
         choices=COUNTRIES, initial='AU', required=False)
 
+    def __init__(self, *args, **kwargs):
+        super(PersonForm, self).__init__(*args, **kwargs)
+        self.fields['short_name'].help_text = \
+            "This is typically the person's given name. "\
+            "For example enter 'Fred' here."
+        self.fields['full_name'].help_text = \
+            "This is typically the person's full name. " \
+            "For example enter 'Fred Smith' here."
+
     class Meta:
         model = Person
         fields = [

--- a/karaage/plugins/kgapplications/forms.py
+++ b/karaage/plugins/kgapplications/forms.py
@@ -114,7 +114,13 @@ class ApplicantForm(forms.ModelForm):
         super(ApplicantForm, self).__init__(*args, **kwargs)
         self.fields['title'].required = True
         self.fields['short_name'].required = True
+        self.fields['short_name'].help_text = \
+            "This is typically your given name. "\
+            "For example enter 'Fred' here."
         self.fields['full_name'].required = True
+        self.fields['full_name'].help_text = \
+            "This is typically your full name. " \
+            "For example enter 'Fred Smith' here."
         self.fields['username'].label = 'Requested username'
         self.fields['username'].required = True
         self.fields['institute'].required = True

--- a/karaage/templates/karaage/people/person_form.html
+++ b/karaage/templates/karaage/people/person_form.html
@@ -28,7 +28,9 @@
 
         <fieldset class="module aligned ()">
             <h2>Personal Details</h2>
-            {% inlineformfield form.title form.short_name form.full_name %}
+            {% formfield form.title %}
+            {% formfield form.short_name %}
+            {% formfield form.full_name %}
             {% inlineformfield form.institute form.department %}
             {% formfield form.position %}
             {% formfield form.supervisor %}


### PR DESCRIPTION
A few users are very confused by the difference between short-name and
long-name on the application form and thus end up repeating their names,
giving a very long "long-name".

Change-Id: Ia093309d911932bb5a85896f27f6213e95305b33