### PR TITLE
improve password fussiness

### DIFF
--- a/karaage/common/forms.py
+++ b/karaage/common/forms.py
@@ -41,10 +41,7 @@ def validate_password(username, password1, password2=None, old_password=None):
         assert_strong_password(username, password1, old_password)
     except ValueError as e:
         raise forms.ValidationError(six.u(
-            'Your password was found to be insecure: %s. '
-            'A good password has a combination of letters '
-            '(uppercase, lowercase), numbers and is at least 8 '
-            'characters long.' % str(e)))
+            'Your password was found to be insecure: %s. ' % str(e)))
 
     # If password1 is ok, return it.
     return password1

--- a/karaage/common/passwords.py
+++ b/karaage/common/passwords.py
@@ -18,6 +18,7 @@
 
 from __future__ import absolute_import
 import logging
+from karaage.conf import settings
 
 
 LOG = logging.getLogger(__name__)
@@ -48,6 +49,15 @@ def assert_strong_password(username, password, old_password=None):
     """Raises ValueError if the password isn't strong.
 
     Returns the password otherwise."""
+
+    # test the length
+    try:
+	minlength = settings.MIN_PASSWORD_LENGTH
+    except AttributeError:
+	minlength = 12
+    if len(password) < minlength:
+        raise ValueError("Password must be at least %s characters long" % minlength)
+
     if username is not None and username in password:
         raise ValueError("Password contains username")
 

--- a/karaage/common/passwords.py
+++ b/karaage/common/passwords.py
@@ -52,9 +52,9 @@ def assert_strong_password(username, password, old_password=None):
 
     # test the length
     try:
-	minlength = settings.MIN_PASSWORD_LENGTH
+        minlength = settings.MIN_PASSWORD_LENGTH
     except AttributeError:
-	minlength = 12
+        minlength = 12
     if len(password) < minlength:
         raise ValueError("Password must be at least %s characters long" % minlength)
 

--- a/karaage/common/passwords.py
+++ b/karaage/common/passwords.py
@@ -18,7 +18,7 @@
 
 from __future__ import absolute_import
 import logging
-from karaage.conf import settings
+from django.conf import settings
 
 
 LOG = logging.getLogger(__name__)

--- a/karaage/management/commands/unlock_training_accounts.py
+++ b/karaage/management/commands/unlock_training_accounts.py
@@ -39,7 +39,7 @@ import tldap.transaction
 # 1.2 - renamed functions _apart & _npart to a_part
 #       & n_part as zope does not allow functions to
 # start with _
-def nicepass(alpha=6, numeric=2):
+def nicepass(alpha=8, numeric=4):
     """
     returns a human-readble password (say rol86din instead of
     a difficult to remember K8Yn9muL )
@@ -111,7 +111,7 @@ class Command(BaseCommand):
         if options['password']:
             password = sys.stdin.readline().strip()
         else:
-            password = nicepass(6, 2)
+            password = nicepass(8, 4)
             print("New password: %s" % password)
 
         for person in query.all():

--- a/karaage/plugins/kgapplications/emails.py
+++ b/karaage/plugins/kgapplications/emails.py
@@ -41,7 +41,7 @@ def _send_request_email(context, role, persons, template):
             settings.APPROVE_ACCOUNTS_EMAIL is not None:
 
         context['receiver'] = None
-        context['receiver_text'] = "Administatror"
+        context['receiver_text'] = "Administrator"
 
         to_email = settings.APPROVE_ACCOUNTS_EMAIL
         subject, body = render_email(template, context)

--- a/karaage/tests/test_people.py
+++ b/karaage/tests/test_people.py
@@ -541,8 +541,8 @@ class PersonTestCase(IntegrationTestCase):
 
         # send new password
         form_data = {
-            'new_password1': 'q1w2e3r4',
-            'new_password2': 'q1w2e3r4',
+            'new_password1': 'VQA#y!xD=BpI<sM69`RW:%',
+            'new_password2': 'VQA#y!xD=BpI<sM69`RW:%',
         }
         done_url = reverse("password_reset_complete")
         response = self.client.post(url, form_data, follow=True)
@@ -552,7 +552,7 @@ class PersonTestCase(IntegrationTestCase):
 
         # test new password
         logged_in = self.client.login(
-            username='kgtestuser1', password='q1w2e3r4')
+            username='kgtestuser1', password='VQA#y!xD=BpI<sM69`RW:%')
         self.assertEqual(logged_in, True)
 
     def test_password_reset_by_admin(self):
@@ -588,8 +588,8 @@ class PersonTestCase(IntegrationTestCase):
 
         # send new password
         form_data = {
-            'new_password1': 'q1w2e3r4',
-            'new_password2': 'q1w2e3r4',
+            'new_password1': 'VQA#y!xD=BpI<sM69`RW:%',
+            'new_password2': 'VQA#y!xD=BpI<sM69`RW:%',
         }
         done_url = reverse("password_reset_complete")
         response = self.client.post(url, form_data, follow=True)
@@ -599,5 +599,5 @@ class PersonTestCase(IntegrationTestCase):
 
         # test new password
         logged_in = self.client.login(
-            username='kgtestuser1', password='q1w2e3r4')
+            username='kgtestuser1', password='VQA#y!xD=BpI<sM69`RW:%')
         self.assertEqual(logged_in, True)

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
 django-extensions==1.7.5
-factory-boy==2.7.0
+factory-boy==2.8.1
 mock==2.0.0
 django-factory==0.11


### PR DESCRIPTION
this commit is the result of a security review at VLSCI. it improves password security as follows:
- password length is checked in assert_strong_password()
- the default minimum password length is now 12 characters
- the default may be configured with a new configuration option, MIN_PASSWORD_LENGTH
- if the password supplied is shorter than the minimum required length, return a ValueError with a string reporting the required length
- the hardcoded string in validate_password() which states the requirements for a good password has been removed as password quality is now configurable