### PR TITLE
Warn if invalid shibboleth session

### DIFF
--- a/karaage/templates/base.html
+++ b/karaage/templates/base.html
@@ -59,6 +59,15 @@
     {% endblock %}
     {% endif %}
 
+    {% if SHIB_SUPPORTED and request.saml_session and not request.saml_logged_in %}
+    <ul class="messagelist">
+      <li class="error">
+          SAML session but failed to log in. See
+          <a href="{% url 'kg_profile_saml' %}">SAML page</a> for SAML
+          session information.</li>
+    </ul>
+    {% endif %}
+
     {% block messages %}
         {% if messages %}
         <ul class="messagelist">{% for message in messages %}


### PR DESCRIPTION
Should fix part of #351. User will get warned if Shibboleth identity cannot be associated with Karaage identity.

Might cause problems with application process, as this condition is expected when associating a shibboleth account with an application.

This also won't solve the issue of not being able to login when in this state, you will still be redirected to the application process instead.